### PR TITLE
no attribute bugs in subscriber callbacks

### DIFF
--- a/packages/vehicle_detection/src/vehicle_avoidance_control_node.py
+++ b/packages/vehicle_detection/src/vehicle_avoidance_control_node.py
@@ -14,15 +14,6 @@ class VehicleAvoidanceControlNode(object):
 	def __init__(self):
 		self.node_name = rospy.get_name()
 		rospack = rospkg.RosPack()
-		self.car_cmd_pub = rospy.Publisher("~car_cmd",
-				Twist2DStamped, queue_size = 1)
-		self.vehicle_detected_pub = rospy.Publisher("~vehicle_detected",
-				BoolStamped, queue_size=1)
-		self.subscriber = rospy.Subscriber("~detection",
-				BoolStamped, self.callback,  queue_size=1)
-		self.sub_vehicle_pose = rospy.Subscriber("~vehicle_pose", VehiclePose, self.cbPose, queue_size=1)
-		self.sub_car_cmd = rospy.Subscriber("~car_cmd_in", Twist2DStamped, self.cbCarCmd, queue_size=1)
-
 		self.config	= self.setupParam("~config", "baseline")
 		self.cali_file_name = self.setupParam("~cali_file_name", "default")
 		rospack = rospkg.RosPack()
@@ -36,7 +27,17 @@ class VehicleAvoidanceControlNode(object):
 		self.loadConfig(self.cali_file)
 		self.controllerInitialization()
 		self.detection_prev=None
+		
+		self.car_cmd_pub = rospy.Publisher("~car_cmd",
+				Twist2DStamped, queue_size = 1)
+		self.vehicle_detected_pub = rospy.Publisher("~vehicle_detected",
+				BoolStamped, queue_size=1)
+		self.subscriber = rospy.Subscriber("~detection",
+				BoolStamped, self.callback,  queue_size=1)
+		self.sub_vehicle_pose = rospy.Subscriber("~vehicle_pose", VehiclePose, self.cbPose, queue_size=1)
+		self.sub_car_cmd = rospy.Subscriber("~car_cmd_in", Twist2DStamped, self.cbCarCmd, queue_size=1)
 
+		
 # 		self.v_gain = 1
 # 		self.vehicle_pose_msg_temp = VehiclePose()
 # 		#self.vehicle_pose_msg_temp = Pose2DStamped()

--- a/packages/vehicle_detection/src/vehicle_detection_node.py
+++ b/packages/vehicle_detection/src/vehicle_detection_node.py
@@ -37,6 +37,7 @@ class VehicleDetectionNode(object):
                           % (self.node_name, self.cali_file))
         self.loadConfig(self.cali_file)
 
+        self.lock = mutex()
         self.sub_image = rospy.Subscriber("~image", CompressedImage,
                                           self.cbImage, queue_size=1)
         self.sub_switch = rospy.Subscriber("~switch", BoolStamped,
@@ -49,7 +50,7 @@ class VehicleDetectionNode(object):
                                                        Image, queue_size=1)
         self.pub_time_elapsed = rospy.Publisher("~detection_time",
                                                 Float32, queue_size=1)
-        self.lock = mutex()
+        
         rospy.loginfo("[%s] Initialization completed" % (self.node_name))
 
     def setupParam(self, param_name, default_value):


### PR DESCRIPTION
In the `__init__` function of node classes, subscribers should always be created at the end of the function. The moment subscribers are created, callbacks start coming in and `no such attribute` errors show up because those attributes are declared later in the `__init__`. While most of the times these errors are harmless, they should be removed anyway before they cause something nasty. 

This fixes in this commit are far from complete. There are a few in duckiebot-interface as well. It would be nice if we keep this in the back of our mind during refactoring.