### PR TITLE
ROS instead of picam IMPORTANT needs merge in shell commands, otherwise calibration is broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ srv/_*.py
 *.pyc
 qtcreator-*
 *.user
+.idea
 
 /planning/cfg
 /planning/docs

--- a/packages/complete_image_pipeline/include/complete_image_pipeline/calibrate_extrinsics.py
+++ b/packages/complete_image_pipeline/include/complete_image_pipeline/calibrate_extrinsics.py
@@ -55,7 +55,7 @@ class CalibrateExtrinsics(D8App):
                 img_msg = rospy.wait_for_message(topic_name, CompressedImage, timeout=10)
                 print('Image captured!')
             except rospy.ROSException as e:
-                print('Didn\'t get any message!: %s' % (e,))
+                print('\n\n\nDidn\'t get any message!: %s\n MAKE SURE YOU USE DT SHELL COMMANDS OF VERSION 4.1.9 OR HIGHER!\n\n\n' % (e,))
 
             bgr = dtu.bgr_from_rgb(dtu.rgb_from_ros(img_msg))
             self.info('Picture taken: %s ' % str(bgr.shape))

--- a/packages/complete_image_pipeline/include/complete_image_pipeline/calibrate_extrinsics.py
+++ b/packages/complete_image_pipeline/include/complete_image_pipeline/calibrate_extrinsics.py
@@ -49,7 +49,7 @@ class CalibrateExtrinsics(D8App):
             print('Let\'s wait for an image. Say cheese!')
             img_msg = None
 
-            rospy.init_node('test')
+            rospy.init_node('calibrate_extrinsics')
 
             try:
                 img_msg = rospy.wait_for_message(topic_name, CompressedImage, timeout=10)

--- a/packages/complete_image_pipeline/include/complete_image_pipeline/calibrate_extrinsics.py
+++ b/packages/complete_image_pipeline/include/complete_image_pipeline/calibrate_extrinsics.py
@@ -30,22 +30,14 @@ class CalibrateExtrinsics(D8App):
         params.add_string('output', default=None, short='-o', help='Output directory', group=g)
 
     def go(self):
+        robot_name = dtu.get_current_robot_name()
+
         output = self.options.output
         if output is None:
             output = 'out-calibrate-extrinsics'  #  + dtu.get_md5(self.options.image)[:6]
             self.info('No --output given, using %s' % output)
 
         if self.options.input is None:
-            for i in range(1000):
-                out = os.path.join(output, 'frame-%03d.jpg' % i)
-                if not os.path.exists(out): break
-
-            self.info('Taking a picture. Say cheese!')
-
-            bgr = dtu.bgr_from_raspistill(out)
-            self.info('Picture taken: %s ' % str(bgr.shape))
-
-        elif self.options.input is 'ROS':
 
             print("{}\nCalibrating using the ROS image stream...\n".format("*"*20))
             import rospy
@@ -54,7 +46,7 @@ class CalibrateExtrinsics(D8App):
             topic_name = os.path.join('/', robot_name, 'camera_node/image/compressed')
             print('Topic to listen to is: %s' % topic_name)
 
-            print('Let\'s wait for an image!')
+            print('Let\'s wait for an image. Say cheese!')
             img_msg = None
 
             rospy.init_node('test')
@@ -67,6 +59,7 @@ class CalibrateExtrinsics(D8App):
                 print('Didn\'t get any message!: %s' % (e,))
 
             bgr = dtu.bgr_from_rgb(dtu.rgb_from_ros(img_msg))
+            self.info('Picture taken: %s ' % str(bgr.shape))
 
         else:
             self.info('Loading input image %s' % self.options.input)

--- a/packages/complete_image_pipeline/include/complete_image_pipeline/calibrate_extrinsics.py
+++ b/packages/complete_image_pipeline/include/complete_image_pipeline/calibrate_extrinsics.py
@@ -44,6 +44,30 @@ class CalibrateExtrinsics(D8App):
 
             bgr = dtu.bgr_from_raspistill(out)
             self.info('Picture taken: %s ' % str(bgr.shape))
+
+        elif self.options.input is 'ROS':
+
+            print("{}\nCalibrating using the ROS image stream...\n".format("*"*20))
+            import rospy
+            from sensor_msgs.msg import CompressedImage
+
+            topic_name = os.path.join('/', robot_name, 'camera_node/image/compressed')
+            print('Topic to listen to is: %s' % topic_name)
+
+            print('Let\'s wait for an image!')
+            img_msg = None
+
+            rospy.init_node('test')
+
+            try:
+                img_msg = rospy.wait_for_message(topic_name, CompressedImage, timeout=10)
+                print('Image captured!')
+
+            except rospy.ROSException as e:
+                print('Didn\'t get any message!: %s' % (e,))
+
+            bgr = dtu.bgr_from_rgb(dtu.rgb_from_ros(img_msg))
+
         else:
             self.info('Loading input image %s' % self.options.input)
             bgr = dtu.bgr_from_jpg_fn(self.options.input)

--- a/packages/complete_image_pipeline/include/complete_image_pipeline/cli_single_image.py
+++ b/packages/complete_image_pipeline/include/complete_image_pipeline/cli_single_image.py
@@ -60,7 +60,7 @@ class SingleImagePipeline(D8App):
                 img_msg = rospy.wait_for_message(topic_name, CompressedImage, timeout=10)
                 print('Image captured!')
             except rospy.ROSException as e:
-                print('Didn\'t get any message!: %s' % (e,))
+                print('\n\n\nDidn\'t get any message!: %s\n MAKE SURE YOU USE DT SHELL COMMANDS OF VERSION 4.1.9 OR HIGHER!\n\n\n' % (e,))
 
             bgr = dtu.bgr_from_rgb(dtu.rgb_from_ros(img_msg))
             self.info('Picture taken: %s ' % str(bgr.shape))

--- a/packages/complete_image_pipeline/include/complete_image_pipeline/cli_single_image.py
+++ b/packages/complete_image_pipeline/include/complete_image_pipeline/cli_single_image.py
@@ -27,8 +27,7 @@ class SingleImagePipeline(D8App):
         params.add_string('image_prep', default='baseline', help="Which image prep to use", group=g)
         params.add_string('anti_instagram', default='baseline', help="Which anti_instagram to use", group=g)
         params.add_string('lane_filter',
-                          # default='baseline',
-                           default='moregeneric_straight',
+                          default='moregeneric_straight',
                           help="Which lane_filter to use", group=g)
 
     def go(self):
@@ -53,14 +52,13 @@ class SingleImagePipeline(D8App):
             topic_name = os.path.join('/', vehicle_name, 'camera_node/image/compressed')
 
             print('Let\'s wait for an image. Say cheese!')
-            img_msg = None
 
+            # Dummy to get ROS message
             rospy.init_node('single_image')
-
+            img_msg = None
             try:
                 img_msg = rospy.wait_for_message(topic_name, CompressedImage, timeout=10)
                 print('Image captured!')
-
             except rospy.ROSException as e:
                 print('Didn\'t get any message!: %s' % (e,))
 
@@ -69,23 +67,15 @@ class SingleImagePipeline(D8App):
 
         gp = GroundProjection(vehicle_name)
 
-        if False:
-            _res = run_pipeline(bgr, gp,
-                                line_detector_name=self.options.line_detector,
-                                image_prep_name=self.options.image_prep,
-                                anti_instagram_name=self.options.anti_instagram,
-                                lane_filter_name=self.options.lane_filter)
-
         dtu.DuckietownConstants.show_timeit_benchmarks = True
         res, _stats = run_pipeline(bgr, gp,
-                            line_detector_name=self.options.line_detector,
-                            image_prep_name=self.options.image_prep,
-                            anti_instagram_name=self.options.anti_instagram,
-                            lane_filter_name=self.options.lane_filter)
+                                   line_detector_name=self.options.line_detector,
+                                   image_prep_name=self.options.image_prep,
+                                   anti_instagram_name=self.options.anti_instagram,
+                                   lane_filter_name=self.options.lane_filter)
 
-        self.info('resizing')
+        self.info('Resizing images..')
         res = dtu.resize_small_images(res)
-        self.info('writing')
+        self.info('Writing images..')
         dtu.write_bgr_images_as_jpgs(res, output)
 
-#        dtu.write_jpgs_to_dir(res, output)


### PR DESCRIPTION
## Description

- Use message from ROS camera node instead of stopping the stream and restarting it for:
    - extrinsic calibration
    - single image pipeline
IMPORTANT needs merge in shell commands, otherwise calibration is broken
## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tests

- [x] Visually checked the published camera stream
- [x] Tested both camera calibration procedures and validation

## Style compliance
Please make sure that all your changes conform to the Duckietown (code style)[link] and code (documentation style)[link] guidelines:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I checked that this pull request is compliant with the Duckietown code style
- [ ] I checked that this pull request is compliant with the Duckietown code documentation style

## Next steps
Please describe if you have any questions, comments, or doubts towards the Duckietown software guardians regarding implementation, code style, running tests, documentation, etc.

## FOR THE REVIEWERS
__IMPORTANT:__ DO NOT CHANGE THIS SECTION!

- [ ] Functionality (is the change necessary and is it implemented in the most appropriate way): @liampaull 
- [ ] Integration testing (verify the tests and run additional if necessary): @?
- [ ] Code style compliance: @aleksandarpetrov
- [ ] Documentation compliance: @surirohit 

_To the reviewers:_ If you deem necessary, request code edits, more tests, documentation update, or additional reviewing. __Do not review your own code!__

_PR Template, last edit 23 Aug 2019_
