### PR TITLE
Remap vehicle avoidance car commands if vehicle avoidance running

### DIFF
--- a/packages/duckietown_demos/launch/master.launch
+++ b/packages/duckietown_demos/launch/master.launch
@@ -195,6 +195,8 @@
 	<!-- car_cmd_switch_node -->
 	<!-- no remappings for car_cmd_switch - full topic names specified in params yaml -->
 	<remap from="car_cmd_switch_node/cmd_lane_following" to="lane_controller_node/lane_control"/>
+	
+	<!-- If running vehicle avoidance, overwrite lane controller car commands with avoidance commands -->
 	<group if="$(arg vehicle_avoidance)">
 			<remap from="vehicle_avoidance_control_node/car_cmd" to="lane_controller_node/car_cmd" />
 	</group>

--- a/packages/duckietown_demos/launch/master.launch
+++ b/packages/duckietown_demos/launch/master.launch
@@ -195,7 +195,7 @@
 	<!-- car_cmd_switch_node -->
 	<!-- no remappings for car_cmd_switch - full topic names specified in params yaml -->
 	<remap from="car_cmd_switch_node/cmd_lane_following" to="lane_controller_node/lane_control"/>
-	<group unless="$(arg vehicle_avoidance)">
+	<group if="$(arg vehicle_avoidance)">
 			<remap from="vehicle_avoidance_control_node/car_cmd" to="lane_controller_node/car_cmd" />
 	</group>
 


### PR DESCRIPTION
## Description

- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context.
- List any dependencies that are required for this change.
- Explicitly mention if the current changes can (or could) break any existing interface or functionality.
- If this pull request results in from a fix to a GitHub issue, give a link to it.

From testing on my Duckiebot, it seems that the Duckiebot does not stop when getting close to the back of another Duckiebot when lane following is running. After investigating the problem, it seems that vehicle avoidance _is_ running and publishes a velocity of 0 when the Duckiebot is close to another Duckiebot, however there is no one subscribed to the vehicle avoidance wheel commands (`vehicle_avoidance_control_node/car_cmd`).

I believe this is because the mapping from vehicle avoidance wheel commands to lane following wheel commands only happens when vehicle avoidance is _off_, but it should be the opposite.

## Type of change

Please mark the relevant options with X:

- [x] Bug fix (non-breaking change which fixes an issue)
- ~~[ ] New feature (non-breaking change which adds functionality)~~
- ~~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- [ ] This change is constrained only to one package, any interfaces to nodes from other packages are maintained
- [ ] This change is constrained only to packages in this repository, any interfaces to nodes from other repositories are maintained
- ~~[ ] This change required a documentation update~~
- ~~[ ] This change is only a documentation update~~
- ~~[ ] This change restructures the repository (at level higher than package level)~~
- ~~[ ] This change requires a change in the Duckiebook (if yes, please describe and, if possible, make a pull request for an edit in the book and link it here)~~

## Tests

Please describe all tests ran and their outcome. It is highly recommended that you at least do the tests listed by default, even if you only changed the documentation.

- [ ] Made the Duckiebot move with keyboard control
- [ ] Visually checked the published camera stream
- [ ] Verified that the lane following demo works
- [ ] Verified that the indefinite navigation demo works

## Style compliance
Please make sure that all your changes conform to the Duckietown (code style)[link] and code (documentation style)[link] guidelines:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I checked that this pull request is compliant with the Duckietown code style
- [x] I checked that this pull request is compliant with the Duckietown code documentation style

## Next steps
Please describe if you have any questions, comments, or doubts towards the Duckietown software guardians regarding implementation, code style, running tests, documentation, etc.

## FOR THE REVIEWERS
__IMPORTANT:__ DO NOT CHANGE THIS SECTION!

- [ ] Functionality (is the change necessary and is it implemented in the most appropriate way): @liampaull or @afdaniele
- [ ] Integration testing (verify the tests and run additional if necessary): @?
- [ ] Code style compliance: @gibernas
- [ ] Documentation compliance: @aleksandarpetrov

_To the reviewers:_ If you deem necessary, request code edits, more tests, documentation update, or additional reviewing. __Do not review your own code!__

_PR Template, last edit 23 Aug 2019_
